### PR TITLE
mock update path progress (mark as completed)

### DIFF
--- a/action/path.ts
+++ b/action/path.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getPathResult } from "@/mock/path_data";
+import { getPathResult, updatePathProgress } from "@/mock/path_data";
 
 // TODO: Implement the actual API call updateRecentlyPath
 
@@ -8,7 +8,8 @@ export const updateRecentlyPath = async (id: string) => {
     if (!id) {
         return;
     }
-    console.log("Update Recently Path: ", id);
+    const resp = await updatePathProgress(id, 100); // Marked as completed only
+    return resp;
 }
 
 export const fetchPath = async (id: string) => {

--- a/app/[lang]/path/[id]/layout.tsx
+++ b/app/[lang]/path/[id]/layout.tsx
@@ -1,0 +1,9 @@
+import { PathContextProvider } from "@/context/Path";
+
+export default function PathLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return <PathContextProvider>{children}</PathContextProvider>;
+}

--- a/app/[lang]/path/[id]/page.tsx
+++ b/app/[lang]/path/[id]/page.tsx
@@ -4,15 +4,15 @@ import PathPageLoading from "@/components/PathPageLoading";
 import DirectedGraph from "@/components/directedGraph/DirectedGraph";
 import { toast } from "@/components/ui/use-toast";
 import { useTranslation } from "@/context/Translation";
-import { PathData } from "@/types/type";
 import { getPathInitialNodesAndEdges } from "@/utils/path";
 import { useEffect, useState } from "react";
 import { ReactFlowProvider } from "reactflow";
 import { fetchPath, updateRecentlyPath } from "@/action/path";
 import { useSearchParams } from "next/navigation";
+import { usePath } from "@/context/Path";
 
 export default function Path({ params }: { params: { id: string } }) {
-  const [data, setData] = useState<PathData | null>(null);
+  const { pathInfo, setPathInfo } = usePath();
   const [error, setError] = useState<string | null>(null);
   const [descriptionHeight, setDescriptionHeight] = useState(0);
   const { dict } = useTranslation();
@@ -30,7 +30,7 @@ export default function Path({ params }: { params: { id: string } }) {
           setError(response.message ? response.message : "Error fetching data");
           return;
         }
-        setData(response.data.path);
+        setPathInfo(response.data.path);
       } catch (error) {
         console.error("Error fetching data:", error);
       }
@@ -51,21 +51,21 @@ export default function Path({ params }: { params: { id: string } }) {
     }
   }, [error]);
 
-  if (!data) {
+  if (!pathInfo) {
     return <PathPageLoading />;
   }
 
   const { initialNodes, initialEdges } = getPathInitialNodesAndEdges(
-    data.groups
+    pathInfo.groups
   );
 
   return (
     <div className="w-screen">
       <div className="w-full absolute">
         <PathDescription
-          name={data.name}
-          description={data.description}
-          tags={data.tags}
+          name={pathInfo.name}
+          description={pathInfo.description}
+          tags={pathInfo.tags}
           setHeight={setDescriptionHeight}
         />
       </div>

--- a/components/MicroContextMenu.tsx
+++ b/components/MicroContextMenu.tsx
@@ -48,7 +48,6 @@ export default function MicroContextMenu({
                       if (node.id === id) {
                         return {
                           ...node,
-                          completed: true,
                           progress: 100
                         };
                       }

--- a/components/MicroContextMenu.tsx
+++ b/components/MicroContextMenu.tsx
@@ -10,6 +10,9 @@ import { useTranslation } from "@/context/Translation";
 import { updateRecentlyPath } from "@/action/path";
 import { usePathname, useRouter } from "next/navigation";
 import I18nTypo from "./ui/I18nTypo";
+import { useEffect, useState } from "react";
+import { toast } from "./ui/use-toast";
+import { usePath } from "@/context/Path";
 
 interface MicroContextMenuProps {
   children: React.ReactNode;
@@ -27,8 +30,49 @@ export default function MicroContextMenu({
   const { dict } = useTranslation();
   const pathName = usePathname();
   const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const { setPathInfo, setSelectedPathId } = usePath();
   const handleMarketComplete = () => {
-    updateRecentlyPath(id);
+    const updateToAPI = async () => {
+      try {
+        const response = await updateRecentlyPath(id);
+        if (response?.status == 200) {
+          setPathInfo((prev) => {
+            if (prev) {
+              return {
+                ...prev,
+                groups: prev.groups.map((group) => {
+                  return {
+                    ...group,
+                    nodes: group.micros.map((node) => {
+                      if (node.id === id) {
+                        return {
+                          ...node,
+                          completed: true,
+                          progress: 100
+                        };
+                      }
+                      return node;
+                    })
+                  };
+                })
+              };
+            }
+            return prev;
+          });
+          setSelectedPathId(id);
+        }
+        if (response?.status != 200) {
+          setError(
+            response?.message ? response.message : "Error fetching data"
+          );
+          return;
+        }
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
+    };
+    updateToAPI();
   };
   const handleViewContent = () => {
     if (microType === MicroType.Video) {
@@ -47,6 +91,17 @@ export default function MicroContextMenu({
       router.push(`${pathName}/video/${id}`);
     }
   };
+
+  useEffect(() => {
+    if (error) {
+      toast({
+        variant: "destructive",
+        title: "Update Progress Error (Mock Only)",
+        description: "Cannot save the progress now!"
+      });
+      setError(null);
+    }
+  }, [error]);
 
   return (
     <ContextMenu>

--- a/components/directedGraph/DirectedGraph.tsx
+++ b/components/directedGraph/DirectedGraph.tsx
@@ -25,6 +25,7 @@ import OrderedGroup from "./OrderNode";
 import SingleGroup from "./SingleNode";
 import UnorderedGroup from "./UnorderNode";
 import { GroupDisplay } from "@/types/enum";
+import { usePath } from "@/context/Path";
 
 const nodeTypes = {
   [GroupDisplay.Single]: SingleGroup,
@@ -47,6 +48,7 @@ export default function DirectedGraph({
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const nodesInitialized = useNodesInitialized();
   const reactFlow = useReactFlow();
+  const { selectedPathId } = usePath();
 
   useEffect(() => {
     if (nodes[0].height === undefined || nodes[0].width === undefined) return;
@@ -141,7 +143,7 @@ export default function DirectedGraph({
       );
       return;
     }
-    if (nodes.length > 0) {
+    if (nodes.length > 0 && selectedPathId === "") {
       const node = findRootNode(initialNodes, nodes);
 
       let nodeWidth = node.width || 0;
@@ -152,7 +154,35 @@ export default function DirectedGraph({
 
       reactFlow.setViewport({ x, y, zoom }, { duration: 1000 });
     }
-  }, [nodes, initialViewport, reactFlow, initialNodes, descriptionHeight]);
+  }, [
+    nodes,
+    initialViewport,
+    reactFlow,
+    initialNodes,
+    descriptionHeight,
+    selectedPathId
+  ]);
+
+  useEffect(() => {
+    setNodes((nds) =>
+      nds.map((node) => {
+        return {
+          ...node,
+          data: {
+            ...node.data,
+            micros: node.data.micros.map((micro) => {
+              if (micro.id !== selectedPathId) return micro;
+              return {
+                ...micro,
+                completed: true,
+                progress: 100
+              };
+            })
+          }
+        };
+      })
+    );
+  }, [selectedPathId, setNodes]);
 
   return (
     <>

--- a/components/directedGraph/DirectedGraph.tsx
+++ b/components/directedGraph/DirectedGraph.tsx
@@ -48,7 +48,7 @@ export default function DirectedGraph({
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const nodesInitialized = useNodesInitialized();
   const reactFlow = useReactFlow();
-  const { selectedPathId } = usePath();
+  const { selectedPathId, pathInfo } = usePath();
 
   useEffect(() => {
     if (nodes[0].height === undefined || nodes[0].width === undefined) return;

--- a/context/Path.tsx
+++ b/context/Path.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { PathData } from "@/types/type";
+import React from "react";
+
+interface PathContextType {
+  pathInfo: PathData | null;
+  setPathInfo: React.Dispatch<React.SetStateAction<PathData | null>>;
+  selectedPathId: string;
+  setSelectedPathId: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const PathContext = React.createContext<PathContextType>({
+  pathInfo: null,
+  setPathInfo: () => {},
+  selectedPathId: "",
+  setSelectedPathId: () => {}
+});
+
+export function usePath() {
+  return React.useContext(PathContext);
+}
+
+export function PathContextProvider({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  const [pathInfo, setPathInfo] = React.useState<PathData | null>(null);
+  const [selectedPathId, setSelectedPathId] = React.useState<string>("");
+  return (
+    <PathContext.Provider
+      value={{ pathInfo, setPathInfo, selectedPathId, setSelectedPathId }}
+    >
+      {children}
+    </PathContext.Provider>
+  );
+}

--- a/mock/path_data.ts
+++ b/mock/path_data.ts
@@ -28,7 +28,7 @@ const directedGraphCase = [
             micros: [
                 { id: '41', name: 'Comment 1', progress: 0, type: MicroType.Video },
                 { id: '42', name: 'Comment 2', progress: 20, type: MicroType.Video },
-                { id: '43', name: 'Comment 3', progress: 80, type: MicroType.Video },
+                { id: '43', name: 'Comment 3', progress: 40, type: MicroType.Video },
             ]
         },
         {
@@ -167,7 +167,7 @@ const directedGraphCase = [
                 { id: '81', name: 'Comment 2 Long Long Long Long Long Long Long Long', progress: 20, type: MicroType.Video },
                 { id: '82', name: 'Comment 3', progress: 40, type: MicroType.Video },
                 { id: '83', name: 'Comment 4', progress: 60, type: MicroType.Video },
-                { id: '84', name: 'Comment 5', progress: 100, type: MicroType.Video },
+                { id: '84', name: 'Comment 5', progress: 10, type: MicroType.Video },
                 { id: '85', name: 'Comment 6', progress: 35, type: MicroType.Video },
             ]
         },
@@ -276,7 +276,7 @@ export function getPathResult(id: string): Promise<PathAPIResponse> { // Mock AP
             }, 2000);
         });
     }
-    mockGroupDB.groups = directedGraphCase[2]
+    mockGroupDB.groups = directedGraphCase[0]
     return new Promise((resolve) => {
         setTimeout(() => {
             resolve({

--- a/mock/path_data.ts
+++ b/mock/path_data.ts
@@ -288,3 +288,37 @@ export function getPathResult(id: string): Promise<PathAPIResponse> { // Mock AP
         }, 0);
     });
 }
+
+export function updatePathProgress(id: string, progress: number): Promise<{ status: number, message?: string }> { // Mock API Response
+    // find path's id in mockDB
+    for (let i = 0; i < directedGraphCase.length; i++) {
+        let paths = directedGraphCase[i]
+        for (let j = 0; j < paths.length; j++) {
+            let group = paths[j]
+            if (group.id == id) {
+                for (let k = 0; k < group.micros.length; k++) {
+                    group.micros[k].progress = progress
+                }
+                break
+            }
+        }
+    }
+
+    if (id == "21") {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve({
+                    status: 500,
+                    message: "Mock Data jaaaaa"
+                });
+            }, 2000);
+        });
+    }
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            resolve({
+                status: 200
+            });
+        }, 0);
+    });
+}


### PR DESCRIPTION
**Objective**
อยากให้เวลาที่กด marked as completed แล้ว progress update ทันทีแบบไม่ต้อง reload หรือ fetch data จาก api ใหม่ เพราะพวกนี้ทำให้ต้อง Rerun algorithm ใหม่ซึ่งสิ้นเปลือง

**Solution**
- เพิ่ม context สำหรับหน้า path ซึ่งประกอบไปด้วย pathInfo (ซึ่งคือข้อมูลของ path) และ selectedId (ซึ่งเป็น id ของ micro ที่ถูก selected ณ ตอนนั้น โดยค่าเริ่มต้นเป็นสตริงว่าง)
-  เมื่อทำการคลิกขวาและกด marked as completed จะมีการอัปเดต selectedId และ pathInfo นี้ (เกิดที่ components/MicroContextMenu.tsx) ซึ่งจะส่งผลให้เฉพาะ node นี้เกิดการ render เพื่ออัปเดตการแสดงผลให้เป็นของสถานะ completed (เกิดที่ components/directedGraph/DirectedGraph.tsx)