### PR TITLE
Chore/show style

### DIFF
--- a/components/MicroTest.tsx
+++ b/components/MicroTest.tsx
@@ -15,7 +15,7 @@ export default function MicroTest({ data, className }: MicroTestProps) {
       id={data.id}
       testLink={data.test?.link}
     >
-      <a href={data.test?.link}>
+      <a href={data.test?.link} target="_blank" rel="noopener noreferrer">
         <div
           className={cn(
             "border-3 p-4 rounded-2xl w-fit",

--- a/components/PathList.tsx
+++ b/components/PathList.tsx
@@ -51,7 +51,7 @@ export default function PathList() {
       {checkIsDataFieldsValid(journeys) &&
         journeys!.data[0].paths.data.map((path) => (
           <div
-            className="pb-2"
+            className="pb-2 max-w-60"
             key={path.id}
             onClick={() => {
               setSelectedPath(getPathDetailFromId(path.id, journeys));


### PR DESCRIPTION
Adjust: When clicking the "Test" microtype, it will open a new tab and navigate to the test page on Chula Mooc.
Fix: When the path name overflows, it should show ellipsis.